### PR TITLE
chore: fixing permissions issue in initial workflow push

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,7 +3,8 @@ name: conventional-commits
 
 on:
   pull_request:
-    branches: main
+    branches:
+      - main
     types:
       - edited
       - opened
@@ -12,4 +13,6 @@ on:
 
 jobs:
   conventional_commit_title:
+    permissions:
+      pull-requests: read
     uses: learning-commons-org/shared-github-actions/.github/workflows/conventional-commits.yml@v1.2.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,5 +7,8 @@ on:
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: learning-commons-org/shared-github-actions/.github/workflows/release-please.yml@v1.2.0
     secrets: inherit


### PR DESCRIPTION
I had forgotten to set job level permissions which led to a [security code scan issue](https://github.com/learning-commons-org/knowledge-graph/security/code-scanning), this PR sets the permissions so that should no longer be an issue.