### PR TITLE
docs: README updates (nav, platform links, structure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://https://platform.learningcommons.org/apps/knowledge-graph/explorer" target="_blank">Try it in the Explorer</a>
    •
-  <a href="https://docs.learningcommons.org/knowledge-graphgetting-started/download-the-data/" target="_blank">Getting set up</a>
+  <a href="https://docs.learningcommons.org/knowledge-graphgetting-started/download-the-data/" target="_blank">Get set up</a>
 </p>
 
 
@@ -36,8 +36,8 @@ You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://pl
 
 You can access the Knowledge Graph data using:
 
-- **REST API**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
-- **MCP server**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
+- **[REST API](https://platform.learningcommons.org/api-keys)**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
+- **[MCP server](https://platform.learningcommons.org/apps/knowledge-graph/mcp-server)**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
 - **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries.
 
 **Note:** The API and MCP server are in Early access and are actively evolving. Changes may occur as we expand capabilities and improve accuracy and reliability. Email [support@learningcommons.org](mailto:support@learningcommons.org)↗ with your feedback or issues.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This filters for nodes with:
 - **Jurisdiction:** `Multi-State` (Common Core)
 - **Academic Subject:** `Mathematics`
 
-## **Support & Feedback**
+## **Support & feedback**
 
 We want to hear from you. For questions or feedback, please [open an issue](https://github.com/learning-commons-org/knowledge-graph/issues) or reach out to us at support@learningcommons.org. 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://pl
 
 You can access the Knowledge Graph data using:
 
-- **REST API**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access. (mailto:support@learningcommons.org)↗ with your feedback or issues.
+- **REST API**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
 - **MCP server**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
 - **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <img style="width:100%" alt="knowledge_graph_banner" src="https://raw.githubusercontent.com/learning-commons-org/.github/refs/heads/main/assets/kg_hero.png" />
 
 <p align="center">
-  <a href="https://docs.learningcommons.org/knowledge-graph/v1-4-0/getting-started/download-the-data/" target="_blank">Getting set up</a>
+  <a href="https://https://platform.learningcommons.org/apps/knowledge-graph/explorer" target="_blank">Try it in the Explorer</a>
+   •
+  <a href="https://docs.learningcommons.org/knowledge-graphgetting-started/download-the-data/" target="_blank">Getting set up</a>
 </p>
 
 
@@ -13,7 +15,7 @@ Key use cases include:
 * **Standards alignment**: Identify how your content supports specific academic standards and create content rooted in learner competencies across all key subjects  
 * **Instructional planning**: Create dependencies, learning progressions, and content coverage, starting with math in the Common Core State Standards  
 * **Compare state standards**: Adapt content aligned to one state standard to other states, initially in math across Common Core State Standards and 15+ additional states  
-* **Curriculum alignment:** Align your content or create additional materials aligned to curriculum (private-beta access only \- details below on how to join)
+* **Curriculum alignment:** Align your content or create additional materials aligned to curriculum (This requires access to a gated dataset. email [support@learningcommons.org](mailto:support@learningcommons.org) for more information.)
 
 Knowledge Graph is distributed as graph-native JSONL export files, making it accessible without specialized infrastructure. These files directly represent the underlying graph model, enabling developers to work with the data in graph databases, while remaining easy to ingest with standard data-processing tools. Developers can load the data into graph databases for relationship-centric querying or transform it for use in relational databases and data pipelines. This structure enables rich querying and supports AI-enhanced educational applications.
 
@@ -26,17 +28,19 @@ For complete setup instructions and usage examples, see the [full docs](https://
 | [tutorials/](./tutorials/) | Standalone example apps to demonstrate how Knowledge Graph data could be applied to solve different use cases |
 | [LICENSE](./LICENSE.md) | Open source license details |
 
-##  **Quick Start**
+## **Try the Knowledge Graph**
+
+You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://platform.learningcommons.org/apps/knowledge-graph/explorer) on the Learning Commons Platform.
+
+##  **Quickstart**
 
 You can access the Knowledge Graph data using:
 
-- **REST API**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access. *(Currently available only to private beta users)*
-- **MCP Server**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. *(Currently available only to private beta users)*
-- **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries. *(Publicly available)*
+- **REST API**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access. (mailto:support@learningcommons.org)↗ with your feedback or issues.
+- **MCP server**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
+- **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries.
 
-### REST API
-
-> **Note:** The API is in limited early release and is only available to some private beta users. Because the API is an early release, current users should expect occasional breaking changes.
+**Note:** The API and MCP server are in Early access and are actively evolving. Changes may occur as we expand capabilities and improve accuracy and reliability. Email [support@learningcommons.org](mailto:support@learningcommons.org)↗ with your feedback or issues.
 
 #### What you'll do
 
@@ -46,8 +50,7 @@ You can access the Knowledge Graph data using:
 
 #### What you'll need
 
-- A Learning Commons Platform account
-- An API key generated in the Learning Commons Platform
+- An API key generated in the [Learning Commons Platform](https://platform.learningcommons.org/)↗
 
 #### Base URL
 
@@ -170,19 +173,10 @@ This filters for nodes with:
 
 We want to hear from you. For questions or feedback, please [open an issue](https://github.com/learning-commons-org/knowledge-graph/issues) or reach out to us at support@learningcommons.org. 
 
-## **Partner with us**
+## **Stay up to date**
+Sign up for a <a href="https://platform.learningcommons.org" target="_blank">Learning Commons account</a> to receive news about the latest Knowledge Graph updates, and releases.
 
-**Learn more about our Knowledge Graph or join our private beta to access:**
-
-* Full curriculum-aligned datasets
-
-* Early access to new features and APIs
-
-* Personalized support from the Knowledge Graph team
-
-Contact us [here](https://learningcommons.org/contact/?utm_source=github&utm_medium=kg&utm_campaign=privatebeta).
-
-## **Reporting Security Issues**
+## **Reporting security issues**
 
 If you believe you have found a security issue, please responsibly disclose by contacting us at [security@learningcommons.org](mailto:security@learningcommons.org).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For complete setup instructions and usage examples, see the [full docs](https://
 
 You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://platform.learningcommons.org/apps/knowledge-graph/explorer) on the Learning Commons Platform.
 
-##  **Accessing Knowledge Graph**
+##  **Access Knowledge Graph**
 
 You can access the Knowledge Graph data using:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img style="width:100%" alt="knowledge_graph_banner" src="https://raw.githubusercontent.com/learning-commons-org/.github/refs/heads/main/assets/kg_hero.png" />
 
 <p align="center">
-  <a href="https://https://platform.learningcommons.org/apps/knowledge-graph/explorer" target="_blank">Try it in the Explorer</a>
+  <a href="https://platform.learningcommons.org/apps/knowledge-graph/explorer" target="_blank">Try it in the Explorer</a>
    •
-  <a href="https://docs.learningcommons.org/knowledge-graphgetting-started/download-the-data/" target="_blank">Get set up</a>
+  <a href="https://docs.learningcommons.org/knowledge-graph/getting-started/download-the-data/" target="_blank">Get set up</a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <p align="center">
   <a href="https://platform.learningcommons.org/apps/knowledge-graph/explorer" target="_blank">Try it in the Explorer</a>
-   •
-  <a href="https://docs.learningcommons.org/knowledge-graph/getting-started/download-the-data/" target="_blank">Get set up</a>
 </p>
 
 
@@ -28,31 +26,33 @@ For complete setup instructions and usage examples, see the [full docs](https://
 | [tutorials/](./tutorials/) | Standalone example apps to demonstrate how Knowledge Graph data could be applied to solve different use cases |
 | [LICENSE](./LICENSE.md) | Open source license details |
 
-## **Try the Knowledge Graph**
+## **Explore the data**
 
 You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://platform.learningcommons.org/apps/knowledge-graph/explorer) on the Learning Commons Platform.
 
-##  **Quickstart**
+##  **Accessing Knowledge Graph**
 
 You can access the Knowledge Graph data using:
 
-- **[REST API](https://platform.learningcommons.org/api-keys)**: Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
-- **[MCP server](https://platform.learningcommons.org/apps/knowledge-graph/mcp-server)**: AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
+- **[REST API](https://platform.learningcommons.org/api-keys)**: Get an API key to Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
+- **[MCP server](https://platform.learningcommons.org/apps/knowledge-graph/mcp-server)**: With the MCP server, AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
 - **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries.
 
 **Note:** The API and MCP server are in Early access and are actively evolving. Changes may occur as we expand capabilities and improve accuracy and reliability. Email [support@learningcommons.org](mailto:support@learningcommons.org)↗ with your feedback or issues.
 
-#### What you'll do
+## Quickstart
+
+### What you'll do
 
 - Authenticate using an API key
 - Get a standards framework identifier (CASE UUID) for Multi-State Mathematics
 - Retrieve a list of academic standards using that framework identifier
 
-#### What you'll need
+### What you'll need
 
 - An API key generated in the [Learning Commons Platform](https://platform.learningcommons.org/)↗
 
-#### Base URL
+### Base URL
 
 All REST API requests should be sent to:
 
@@ -60,7 +60,7 @@ All REST API requests should be sent to:
 https://api.learningcommons.org/knowledge-graph/v0
 ```
 
-#### Authentication
+### Authentication
 
 Include your API key in the `x-api-key` header on every request:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can explore the Knowledge Graph in the [Knowledge Graph Explorer](https://pl
 
 You can access the Knowledge Graph data using:
 
-- **[REST API](https://platform.learningcommons.org/api-keys)**: Get an API key to Authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
+- **[REST API](https://platform.learningcommons.org/api-keys)**: Get an API key to authenticate and make HTTP requests to retrieve academic standards directly. Best for applications that need real-time access.
 - **[MCP server](https://platform.learningcommons.org/apps/knowledge-graph/mcp-server)**: With the MCP server, AI models can reliably work with academic standards, learning components, and learning progressions. They can resolve standards, decompose them into granular learning components, and trace progressions across standards. 
 - **Local JSONL**: Download local JSONL files and query them directly. Best for offline access, custom processing, or complex queries.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Include your API key in the `x-api-key` header on every request:
 x-api-key: YOUR_API_KEY
 ```
 
-#### STEP 1: Get a standards framework identifier
+### STEP 1: Get a standards framework identifier
 
 Use your preferred HTTP client to send a GET request to the standards frameworks endpoint to get the CASE UUID for Multi-State Mathematics.
 
@@ -80,7 +80,7 @@ curl -X GET \
 
 You should receive a 200 response with the CCSS Math framework for Multi-State, including the framework name, jurisdiction, adoption status, and a `caseIdentifierUUID` (GUID). Copy the `caseIdentifierUUID` from the response for the next step.
 
-#### STEP 2: Retrieve academic standards
+### STEP 2: Retrieve academic standards
 
 Use the `caseIdentifierUUID` you copied from Step 1's response with the academic standards endpoint to retrieve the individual standards for that framework.
 
@@ -129,16 +129,16 @@ Example response:
 }
 ```
 
-### Local JSONL Files
+## Local JSONL Files
 
 The Knowledge Graph data is available for download in newline delimited JSONL format with UTF-8 encoding. The graph data is exported with `nodes.jsonl` representing the nodes of the knowledge graph and the `relationships.jsonl` file capturing the connections between nodes.
 
-#### Files
+### Files
 
 - `nodes.jsonl`: Contains graph node records, defining each node by a unique identifier, labels, and a set of associated properties.
 - `relationships.jsonl`: Contains graph relationship records, describing how nodes are connected, including the relationship type, properties, and the source and target nodes.
 
-#### Download options
+## Download options
 
 You can download the files through direct links or using curl commands.
 
@@ -156,7 +156,7 @@ curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.7.0/exports/nodes.js
 curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.7.0/exports/relationships.jsonl?ref=gh_curl" -o relationships.jsonl
 ```
 
-#### Querying with jq
+### Querying with jq
 
 One option for querying the JSONL files is to use [jq](https://jqlang.github.io/jq/). Example to extract Common Core math standards:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Example response:
 }
 ```
 
-## Local JSONL Files
+## Local JSONL files
 
 The Knowledge Graph data is available for download in newline delimited JSONL format with UTF-8 encoding. The graph data is exported with `nodes.jsonl` representing the nodes of the knowledge graph and the `relationships.jsonl` file capturing the connections between nodes.
 
@@ -138,7 +138,7 @@ The Knowledge Graph data is available for download in newline delimited JSONL fo
 - `nodes.jsonl`: Contains graph node records, defining each node by a unique identifier, labels, and a set of associated properties.
 - `relationships.jsonl`: Contains graph relationship records, describing how nodes are connected, including the relationship type, properties, and the source and target nodes.
 
-## Download options
+### Download options
 
 You can download the files through direct links or using curl commands.
 


### PR DESCRIPTION
Updates the Knowledge Graph README to align with recent Evaluators-style layout: Explorer CTA, Explore the data / Access Knowledge Graph sections, Stay up to date, support heading consistency, REST API & MCP links, JSONL heading levels, and assorted copy fixes.

Made with [Cursor](https://cursor.com)