### PR TITLE
chore: update download links to version 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,16 @@ You can download the files through direct links or using curl commands.
 
 **Direct links**
 
-- [nodes.jsonl](https://cdn.learningcommons.org/knowledge-graph/v1.12.0/exports/nodes.jsonl?ref=github)
-- [relationships.jsonl](https://cdn.learningcommons.org/knowledge-graph/v1.12.0/exports/relationships.jsonl?ref=github)
+- [nodes.jsonl](https://cdn.learningcommons.org/knowledge-graph/v1.13.0/exports/nodes.jsonl?ref=github)
+- [relationships.jsonl](https://cdn.learningcommons.org/knowledge-graph/v1.13.0/exports/relationships.jsonl?ref=github)
 
 **Using curl commands**
 
 If you don't have curl installed, visit https://github.com/curl/curl for installation instructions.
 
 ```bash
-curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.12.0/exports/nodes.jsonl?ref=gh_curl" -o nodes.jsonl
-curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.12.0/exports/relationships.jsonl?ref=gh_curl" -o relationships.jsonl
+curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.13.0/exports/nodes.jsonl?ref=gh_curl" -o nodes.jsonl
+curl -L "https://cdn.learningcommons.org/knowledge-graph/v1.13.0/exports/relationships.jsonl?ref=gh_curl" -o relationships.jsonl
 ```
 
 #### Querying with jq


### PR DESCRIPTION
**Thanks for your interest in our project\!**

This repository is currently being maintained internally, so we’re not accepting external contributors.

However, if you’ve discovered a bug or have a feature suggestion, please feel free to open an issue or reach out to us at [support@learningcommons.org](mailto:support@learningcommons.org). 

If you believe you have found a security issue, please responsibly disclose by contacting us at [security@learningcommons.org](mailto:security@learningcommons.org).

If you are interested in partnering with us, fill out [this form](https://learningcommons.org/contact/?utm_source=github&utm_medium=overview&utm_campaign=privatebeta) to get in touch.
