### PR TITLE
chore: Update CHANGELOG for v1.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Knowledge Graph [v1.13.1](https://github.com/learning-commons-org/knowledge-graph/compare/v1.13.0...v1.13.1) (2026-09-09)
+
+**September 9, 2026**
+
+### Data v1.13.1
+
+- Restored the [`jaccard`](https://docs.learningcommons.org/knowledge-graph/schema-reference/standards#understanding-the-jaccard-score) property on [`hasStandardAlignment`](https://docs.learningcommons.org/knowledge-graph/schema-reference/standards#hasstandardalignment) relationships (unintentionally removed in [v1.12.0](#v1-12-0))
+
 ## Knowledge Graph [v1.13.0](https://github.com/learning-commons-org/knowledge-graph/compare/v1.12.0...v1.13.0) (2026-08-27)
 
 **August 27, 2026**


### PR DESCRIPTION
## Knowledge Graph [v1.13.1](https://github.com/learning-commons-org/knowledge-graph/compare/v1.13.0...v1.13.1) (2026-09-09)

**September 9, 2026**

### Data v1.13.1

- Restored the [`jaccard`](https://docs.learningcommons.org/knowledge-graph/schema-reference/standards#understanding-the-jaccard-score) property on [`hasStandardAlignment`](https://docs.learningcommons.org/knowledge-graph/schema-reference/standards#hasstandardalignment) relationships (unintentionally removed in [v1.12.0](#v1-12-0))
